### PR TITLE
Fix creating data directories for timeservices

### DIFF
--- a/rootdir/init.qcom.rc
+++ b/rootdir/init.qcom.rc
@@ -156,6 +156,10 @@ on boot
 
 # msm specific files that need to be created on /data
 on post-fs-data
+    # Create directory used by time-services
+    mkdir /data/time 0700 system system
+    mkdir /data/vendor/time 0700 system system
+
     mkdir /data/vendor/misc 01771 system system
 
     # Create directory used by display clients


### PR DESCRIPTION
Change-Id: I34cb7443cc229a91a30cae082dfecf1d5a10e50f

This is sufficient on my personal LineageOS 15.1 builds for `santoni` to fix this issue: https://gitlab.com/LineageOS/issues/android/-/issues/1411

If a file_context for this directory should be added as well or if other `msm8937` devices are not affected by this issue then act as you see fit.

At least on the Redmi 4X (`santoni`), these directories are required to store the clock deltas. If they are not present, the affected qc-timeservices will fail to create them and thus never store the essential clock delta when changing the system time.